### PR TITLE
fix: handle empty keys

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -83,7 +83,7 @@ var LivePatch = function(fn) {
 	this.parser.onopenobject = function(key) {
 		self._startObject();
 
-		if (key) {
+		if (typeof key !== 'undefined') {
 			self._pushKey(key);
 		}
 	};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "livepatch",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Patch JSON streams on the fly",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/pagarme/livepatch",
   "dependencies": {
-    "clarinet": "^0.11.0",
+    "clarinet": "0.12.0",
     "through2": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Livepatch breaks on empty keys.

Example:
```json
{
  "": 123
}
```

This PR allows livepatch to handle empty keys.